### PR TITLE
[DEVED-4392] Remove iteration, saving locally

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -8,34 +8,15 @@ GOOD_BOY = 'https://images.unsplash.com/photo-1518717758536-85ae29035b6d?ixlib=r
 post '/whatsapp' do
   num_media = params['NumMedia'].to_i
 
-  if num_media > 0
-    for i in 0..(num_media - 1) do
-      # Prepare the file information
-      media_url = params["MediaUrl#{i}"]
-      content_type = params["MediaContentType#{i}"]
-      file_name = media_url.split('/').last
-      file_extension = MIME::Types[content_type].first.extensions.first
-      file = "storage/#{file_name}.#{file_extension}"
-
-      # Dowload the files
-      open(media_url) do |url|
-        File.open(file, 'wb') do |f|
-          f.write(url.read)
-        end
-      end
-
-    end
-  end
-
   # Reply message
   response = Twilio::TwiML::MessagingResponse.new
   response.message do |message|
     if num_media == 0
       message.body 'Send us an image!'
     else
-      message.body 'Thanks for the image(s).'
+      message.body 'Thanks for the image! Here\'s one for you!'
+      message.media GOOD_BOY
     end
-    message.media GOOD_BOY
   end
 
   content_type 'text/xml'

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe 'whatsapp webhook tests' do
 
     expect(last_response).to be_ok
     expect(last_response.body).to include('<Body>Send us an image!</Body>')
-    expect(last_response.body).to include("<Media>#{CGI.escapeHTML(GOOD_BOY)}</Media>")
   end
 
   it 'test post with an image' do
@@ -29,7 +28,7 @@ RSpec.describe 'whatsapp webhook tests' do
     post '/whatsapp' , params={:NumMedia => 1, :MediaUrl0 => 'http://sample.org/file', :MediaContentType0 => 'text/plain'}
 
     expect(last_response).to be_ok
-    expect(last_response.body).to include('<Body>Thanks for the image(s).</Body>')
+    expect(last_response.body).to include('<Body>Thanks for the image! Here\'s one for you!</Body>')
     expect(last_response.body).to include("<Media>#{CGI.escapeHTML(GOOD_BOY)}</Media>")
   end
 


### PR DESCRIPTION
This commit removes iteration over `num_media` because there is only one file in a WhatsApp message. Local saving of files it also removed.